### PR TITLE
fix(package): add exports to package.json for proper imports

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,11 +1,3 @@
 {
-  "extends": "@artsy",
-  "plugins": [
-    [
-      "npm",
-      {
-        "publishFolder": "./dist"
-      }
-    ]
-  ]
+  "extends": "@artsy"
 }

--- a/package.json
+++ b/package.json
@@ -2,16 +2,26 @@
   "name": "@artsy/icons",
   "version": "3.0.1",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
   "scripts": {
     "build": "yarn clean && yarn optimize && node scripts/build.js && yarn compile",
     "build:docs": "yarn build && cd docs && yarn install && yarn export",
     "clean": "rm -rf .build/svg && rm -rf .build/src",
-    "compile": "tsc -p . && cp .build/src/package.json dist/package.json",
+    "compile": "tsc -p .",
     "docs": "yarn build && cd docs && yarn install && yarn refresh && yarn dev",
     "optimize": "svgo src -o .build/svg --config=svgo.config.js",
     "prepublish": "yarn build",
     "release": "auto shipit"
+  },
+  "peerDependencies": {
+    "react": ">=16.2.0",
+    "styled-components": "^4",
+    "styled-system": "^5"
   },
   "devDependencies": {
     "@artsy/auto-config": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/icons",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": "dist/index.js",
   "license": "MIT",
   "scripts": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,14 +1,13 @@
-"use strict";
+// @ts-check
 
 const glob = require("glob");
 const fs = require("fs-extra");
 const path = require("path");
-const { version } = require("../package.json");
 const write = require("./write");
 
 if (!fs.existsSync(".build/svg")) {
   console.error("Requires optimization step to be run first");
-  return;
+  process.exit(1)
 }
 
 const filepaths = glob.sync(".build/svg/*.svg");
@@ -19,7 +18,6 @@ const files = write({
     path: filepath,
     source: fs.readFileSync(filepath, { encoding: "utf8" }),
   })),
-  version,
 });
 
 files.forEach((file) => {

--- a/scripts/write.js
+++ b/scripts/write.js
@@ -47,7 +47,10 @@ const getPackageJsonSource = ({ version }) => `{
     "styled-components": "^4",
     "styled-system": "^5"
   },
-  "main": "index.js",
+  "main": "./dist/index.js",
+  "exports": {
+    "./": "./dist"
+  }
   "types": "index.d.ts",
   "publishConfig": {
     "access": "public",

--- a/scripts/write.js
+++ b/scripts/write.js
@@ -39,25 +39,6 @@ export default ${componentName};
 `;
 };
 
-const getPackageJsonSource = ({ version }) => `{
-  "name": "@artsy/icons",
-  "version": "${version}",
-  "peerDependencies": {
-    "react": ">=16.2.0",
-    "styled-components": "^4",
-    "styled-system": "^5"
-  },
-  "main": "./dist/index.js",
-  "exports": {
-    "./": "./dist"
-  },
-  "types": "index.d.ts",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org"
-  }
-}`;
-
 const getBoxSource = () => `
 import styled from "styled-components";
 import { FlexboxProps, LayoutProps, PositionProps, SpaceProps, ColorProps, flexbox, layout, position, space, color, ResponsiveValue, style } from "styled-system";
@@ -88,7 +69,7 @@ ${iconFiles
   .join("\n")}
 `;
 
-const write = ({ svgs, version }) => {
+const write = ({ svgs }) => {
   const iconFiles = svgs.map((svg) => {
     const name = path.basename(svg.path).replace(".svg", "");
     const componentName = `${upperFirst(camelCase(name))}Icon`;
@@ -121,7 +102,6 @@ const write = ({ svgs, version }) => {
   });
 
   return [
-    { filepath: "package.json", source: getPackageJsonSource({ version }) },
     { filepath: "index.ts", source: getIndexSource({ iconFiles }) },
     { filepath: "Box.tsx", source: getBoxSource() },
     ...iconFiles,

--- a/scripts/write.js
+++ b/scripts/write.js
@@ -50,7 +50,7 @@ const getPackageJsonSource = ({ version }) => `{
   "main": "./dist/index.js",
   "exports": {
     "./": "./dist"
-  }
+  },
   "types": "index.d.ts",
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
Updates package.json write process so that we can import from the `dist` folder
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.0.2--canary.14.149.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/icons@3.0.2--canary.14.149.0
  # or 
  yarn add @artsy/icons@3.0.2--canary.14.149.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
