### PR TITLE
fix(exports): constrain export paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@ yarn add @artsy/icons
 And then later, import icons like so:
 
 ```tsx
-import { ArtsyLogo } from "@artsy/icons"
+import ArtsyLogo from "@artsy/icons/ArtsyLogo"
 
 const MyApp = () => {
   return <ArtsyLogo />
 }
 ```
+
+Alternatively, visit [the docs](https://icons.artsy.net) and select individual icons, which will copy the import path to your clipboard.
 
 ## Adding New Icons
 

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from "next";
 import Head from "next/head";
-import * as Icons from "@artsy/icons";
+import * as Icons from "@artsy/icons/allIcons";
 import {
   Box,
   Column,

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@artsy/icons",
   "version": "3.0.2",
   "main": "dist/index.js",
+  "exports": {
+    ".": "./dist/*.js"
+  },
   "types": "dist/index.d.ts",
   "license": "MIT",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.2",
   "main": "dist/index.js",
   "exports": {
-    ".": "./dist/*.js"
+    "./*": "./dist/*.js"
   },
   "types": "dist/index.d.ts",
   "license": "MIT",
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "yarn clean && yarn optimize && node scripts/build.js && yarn compile",
     "build:docs": "yarn build && cd docs && yarn install && yarn export",
-    "clean": "rm -rf .build/svg && rm -rf .build/src",
+    "clean": "rm -rf .build/svg && rm -rf .build/src && rm -rf dist",
     "compile": "tsc -p .",
     "docs": "yarn build && cd docs && yarn install && yarn refresh && yarn dev",
     "optimize": "svgo src -o .build/svg --config=svgo.config.js",

--- a/scripts/write.js
+++ b/scripts/write.js
@@ -102,7 +102,7 @@ const write = ({ svgs }) => {
   });
 
   return [
-    { filepath: "index.ts", source: getIndexSource({ iconFiles }) },
+    { filepath: "allIcons.ts", source: getIndexSource({ iconFiles }) },
     { filepath: "Box.tsx", source: getBoxSource() },
     ...iconFiles,
   ];


### PR DESCRIPTION
This aliases exports so that one can import directly from the root. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.1.0--canary.16.182.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/icons@3.1.0--canary.16.182.0
  # or 
  yarn add @artsy/icons@3.1.0--canary.16.182.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
