### PR TITLE
fix(package): add typedExports for dts support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,13 @@
   "exports": {
     "./*": "./dist/*.js"
   },
-  "types": "dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/*"
+      ]
+    }
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
In order to read subpath-aliased dts files, we need to add the [`typedExports` path](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.1.1--canary.17.209.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/icons@3.1.1--canary.17.209.0
  # or 
  yarn add @artsy/icons@3.1.1--canary.17.209.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
