### PR TITLE
fix: do not remove fill attributes for credit card icons

### DIFF
--- a/svgo/removeAttrsIfSameFill.js
+++ b/svgo/removeAttrsIfSameFill.js
@@ -3,6 +3,7 @@
 const { selectAll } = require("css-select")
 const xastAdaptor = require("svgo/lib/svgo/css-select-adapter")
 const removeAttrs = require("svgo/plugins/removeAttrs")
+const path = require('path')
 
 const CSS_SELECT_OPTIONS = {
   xmlMode: true,
@@ -13,6 +14,17 @@ const PLUGIN_NAME = "removeAttrsIfSameFill"
 const ENOATTRS = `Warning: The plugin "${PLUGIN_NAME}" requires the "attrs" parameter.
 It should have a pattern to remove, otherwise the plugin is a noop.
 `
+
+const IGNORED_FILES = [
+  "Amex",
+  "CartesBancaires",
+  "DinersClub",
+  "Discover",
+  "JCB",
+  "Mastercard",
+  "UnionPay",
+  "Visa",
+]
 
 exports.name = PLUGIN_NAME
 exports.type = "full"
@@ -27,6 +39,12 @@ exports.fn = (ast, params, info) => {
   if (typeof params.attrs == "undefined") {
     console.warn(ENOATTRS)
     return null
+  }
+
+  const filename = path.parse(info.path).name
+
+  if (IGNORED_FILES.includes(filename)) {
+    return
   }
 
   const attrs = Array.isArray(params.attrs) ? params.attrs : [params.attrs]


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/EMI-2063 and [Slack thread](https://artsy.slack.com/archives/C02JHHHKP5K/p1729531380826009).

We remove the `fill` attributes of a svg, via a [custom plugin](https://github.com/artsy/icons/blob/912475749c8efcd279ea13e3d77930e7f7e6c667/svgo/removeAttrsIfSameFill.js), if all elements excluding `none`, `white`, and `black` filled elements are the same fill color, and then we color icons afterwards.

For credit cards that fill color in ways like patterns, this might not work for the same goal, and they are rendered in black. Given that we'll not color credit card icons programmatically, this skip the processing for credit card icons, and simply respect the color from the SVG files.

![Screenshot 2024-10-21 at 3 12 19 PM](https://github.com/user-attachments/assets/febe0c8f-7310-4115-8a74-8a06b4ebcdb4)

Running docs locally gives the colored results:

![Screenshot 2024-10-21 at 3 18 21 PM](https://github.com/user-attachments/assets/3ac84cbc-8739-4112-a1c0-71dd0b3d716a)

@artsy/emerald-devs 