### PR TITLE
chore(MOPRAT-841): Add ArrowheadUpFilledIcon

### DIFF
--- a/src/ArrowheadUpFilled.svg
+++ b/src/ArrowheadUpFilled.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M17 9A8 8 0 1 1 1 9a8 8 0 0 1 16 0M9 5.572l-3.429 5.943h6.858z" fill="#000"/>
+</svg>


### PR DESCRIPTION
This PR resolves [MOPRAT-841]

### Description
This PR adds a new icon `ArrowheadUpFilledIcon`, renamed from `ArrowUpCircleFillIcon`, so that it's not confused with the current Arrow icons we currently have in Artsy Icons (arrow icons in Palette Mobile are chevron icons in Artsy Icons)

But I'm open to different naming for the icon

### New Icon 
<img width="450" alt="image" src="https://github.com/user-attachments/assets/e1978d2c-ca04-4933-9718-4527d12c2a3c" />
