### PR TITLE
chore(MOPRAT-840): Add ArrowheadDownCircleFillIcon

### DIFF
--- a/src/ArrowheadDownCircleFill.svg
+++ b/src/ArrowheadDownCircleFill.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M17 9A8 8 0 1 0 1 9a8 8 0 0 0 16 0m-8 3.428L5.571 6.485h6.858z" fill="black"/>
+</svg>


### PR DESCRIPTION
This PR resolves [MOPRAT-840]

### Description
This PR adds a new icon `ArrowheadDownCircleFillIcon`, renamed from ArrowDownCircleFillIcon, so that it's not confused with the current Arrow icons we currently have in Artsy Icons

### New Icon
<img width="574" alt="image" src="https://github.com/user-attachments/assets/db61930d-80af-4fe7-9843-51810720d3ff" />


[MOPRAT-840]: https://artsyproduct.atlassian.net/browse/MOPRAT-840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ