### PR TITLE
fix: Update arrowhead sizes

### DIFF
--- a/src/ArrowheadDownCircleFill.svg
+++ b/src/ArrowheadDownCircleFill.svg
@@ -1,3 +1,3 @@
 <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M17 9A8 8 0 1 0 1 9a8 8 0 0 0 16 0m-8 3.428L5.571 6.485h6.858z" fill="black"/>
+  <path d="M16 9A7 7 0 1 0 2 9a7 7 0 0 0 14 0m-7 3L6 6.8h6z" fill="black"/>
 </svg>

--- a/src/ArrowheadUpCircleFill.svg
+++ b/src/ArrowheadUpCircleFill.svg
@@ -1,3 +1,3 @@
 <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M17 9A8 8 0 1 1 1 9a8 8 0 0 1 16 0M9 5.572l-3.429 5.943h6.858z" fill="#000"/>
+  <path d="M16 9A7 7 0 1 1 2 9a7 7 0 0 1 14 0M9 6l-3 5.2h6z" fill="black"/>
 </svg>


### PR DESCRIPTION
### Description

This PR adjusts the size of the Arrowhead icons

| Before | <img width="1470" alt="image" src="https://github.com/user-attachments/assets/0b5f65a1-543a-4fe8-8f0b-e29bd3b72e39" /> 
|---|---|
| After | <img width="1470" alt="image" src="https://github.com/user-attachments/assets/e16dd360-5d2a-4536-8aa5-7a6214f4ca05" /> |
