### PR TITLE
chore: expose native base icon

### DIFF
--- a/scripts/writeNative.js
+++ b/scripts/writeNative.js
@@ -109,6 +109,7 @@ ${iconFiles
 
 const getIndexSource = () => `
 export * from "./allIcons";
+export * from "./Icon";
 `
 
 const writeNative = ({ svgs }) => {


### PR DESCRIPTION
### Description
This PR exposes the native base icon to be able to use the IconProps type