### PR TITLE
feat(MOPRAT-859): Add TriangleDown icon

### DIFF
--- a/src/TriangleDown.svg
+++ b/src/TriangleDown.svg
@@ -1,0 +1,3 @@
+<svg width="11" height="6" viewBox="0 0 11 6" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M5.5 6L0 0L11 0L5.5 6Z" fill="black"/>
+</svg>


### PR DESCRIPTION
This PR resolves [EMI-859]

### Description
This PR adds the TriangleDown icon


<img width="213" height="132" alt="image" src="https://github.com/user-attachments/assets/f6056796-4f80-47c4-a36f-f7eeebb919cf" />


[EMI-859]: https://artsyproduct.atlassian.net/browse/EMI-859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ