### PR TITLE
feat: add copy icon

### DIFF
--- a/src/Copy.svg
+++ b/src/Copy.svg
@@ -1,0 +1,4 @@
+<svg width="13" height="13" viewBox="0 0 13 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10.7582 2.24121H0V12.9998H10.7582V2.24121ZM9.86169 12.1033H0.896518V3.13776H9.86169V12.1033Z" fill="black"/>
+<path d="M2.24121 1.56896H3.13773V0.896549H12.1029V9.86204H11.4709V10.7586H12.9994V0H2.24121V1.56896Z" fill="black"/>
+</svg>


### PR DESCRIPTION
Adding a copy icon to Icons to use on ArtOS 
https://github.com/artsy/volt/pull/11974/changes/BASE..501e40b345541cf949f8b9a28dda3dbdbd30687a#r3819858603

<img width="598" height="156" alt="image" src="https://github.com/user-attachments/assets/8447e2d5-05e6-42e3-8d9b-a8f8ff21a026" />
